### PR TITLE
Changes to date labels and making check-in date non-editable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ stats.json
 npm-debug.log
 .idea
 
-.env
+.env*

--- a/src/app/Review.js
+++ b/src/app/Review.js
@@ -358,13 +358,13 @@ class Review extends React.Component {
                         <div className={dateErrors.endDate ? 'col-sm-12 invalid' : 'col-sm-12'}>
                           <label htmlFor="endDate" className="col-sm-4" style={{ textAlign: 'right' }}>Date of this check-in: </label>
                           <div className="col-sm-8">
-                            {this.state.answersEditable &&
+                            {/* {this.state.answersEditable &&
                               <DatePickerWrapper selected={moment.utc(this.state.periodEnd)} id="endDate" onChange={value => this.handleEndDateChange(value, submit)} />
                             }
                             {this.state.answersEditable && dateErrors.endDate &&
                               <span style={{ color: 'red', fontWeight: 'bold', marginLeft: '10px' }}>&apos;Date of this check-in&apos; is required</span>
-                            }
-                            {!this.state.answersEditable &&
+                            } */}
+                            {// !this.state.answersEditable &&
                               <span>{moment.utc(this.state.periodEnd).format('M/DD/YYYY')}</span>
                             }
                           </div>

--- a/src/app/ReviewsTable.js
+++ b/src/app/ReviewsTable.js
@@ -31,7 +31,7 @@ const getTimeSinceLastConversation = (reviewDate, reviewable) => {
 
 const dataColumnsCurrent = [
   {
-    Header: (<div>Check-in Date</div>),
+    Header: (<div>Last Save</div>),
     id: 'periodEnd',
     accessor: review => (<span title="View check-in">{moment.utc(review.periodEnd).format('M/DD/YYYY')}</span>),
     minWidth: 160,
@@ -59,7 +59,7 @@ const dataColumnsCurrent = [
     minWidth: 300,
   },
   {
-    Header: 'Last Change',
+    Header: 'Last Status Change',
     id: 'status_date',
     accessor: review => (<span>{moment.utc(review.status_date).format('M/DD/YYYY')}</span>),
     maxWidth: 200,


### PR DESCRIPTION
Pretty minor changes - should work with either current or dev versions of check-ins (except that I haven't implemented the logic to update dates in the current version).
